### PR TITLE
fix: Nextjs page export

### DIFF
--- a/app/projekty/[slug]/page.tsx
+++ b/app/projekty/[slug]/page.tsx
@@ -20,7 +20,7 @@ export interface PostData {
   content: string;
 }
 
-export async function getPostData(slug: string) {
+async function getPostData(slug: string) {
   const filePath = path.join(postsDirectory, `${slug}.md`);
   try {
     const fileContents = fs.readFileSync(filePath, "utf8");


### PR DESCRIPTION
Fixed build issue. You cannot export any stuff that you want in page.tsx. Only stuff that are in the nextjs Page type definition.